### PR TITLE
chore: fix link to contributing.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -12,7 +12,7 @@ A library to coerce an input value to another type
 
 # Contributing
 
-See [the contributing file](https://github.com/AeroService/.github/CONTRIBUTING.md)!
+See [the contributing file](https://github.com/AeroService/.github/blob/main/CONTRIBUTING.md)!
 All WIP features are previewed as Draft PRs!
 
 # License


### PR DESCRIPTION
### Motivation

Currently the link to the contributing.md is not working, because it is incorrect.

### Modification

Add the correct name to the link url.

### Result

The link to the contributing.md is working now.